### PR TITLE
feat: add -t flag to display elapsed timestamps per message

### DIFF
--- a/cmd/cclean/main.go
+++ b/cmd/cclean/main.go
@@ -9,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/ariel-frischer/claude-clean/display"
 	"github.com/ariel-frischer/claude-clean/parser"
@@ -19,11 +20,12 @@ var Version = "dev"
 
 // Command line flags
 var (
-	verbose     = flag.Bool("V", false, "Show verbose output (usage stats, tool IDs)")
-	showVersion = flag.Bool("v", false, "Show version")
-	styleFlag   = flag.String("s", "default", "Output style: default, compact, minimal, plain")
-	showLineNum = flag.Bool("n", false, "Show line numbers")
-	uninstall   = flag.Bool("uninstall", false, "Uninstall cclean from the system")
+	verbose        = flag.Bool("V", false, "Show verbose output (usage stats, tool IDs)")
+	showVersion    = flag.Bool("v", false, "Show version")
+	styleFlag      = flag.String("s", "default", "Output style: default, compact, minimal, plain")
+	showLineNum    = flag.Bool("n", false, "Show line numbers")
+	showTimestamps = flag.Bool("t", false, "Show elapsed time for each message")
+	uninstall      = flag.Bool("uninstall", false, "Uninstall cclean from the system")
 )
 
 func main() {
@@ -77,9 +79,10 @@ func main() {
 	}
 
 	cfg := &display.Config{
-		Style:       style,
-		Verbose:     *verbose,
-		ShowLineNum: *showLineNum,
+		Style:          style,
+		Verbose:        *verbose,
+		ShowLineNum:    *showLineNum,
+		ShowTimestamps: *showTimestamps,
 	}
 
 	args := flag.Args()
@@ -130,6 +133,10 @@ func processFile(filename string, cfg *display.Config) {
 }
 
 func processStream(r *os.File, cfg *display.Config) {
+	if cfg.ShowTimestamps {
+		cfg.StartTime = time.Now()
+	}
+
 	scanner := bufio.NewScanner(r)
 	scanner.Buffer(make([]byte, 0, parser.MaxBufferCapacity), parser.MaxBufferCapacity)
 

--- a/display/compact.go
+++ b/display/compact.go
@@ -25,7 +25,7 @@ func displaySystemMessageCompact(msg *parser.StreamMessage, lineNum int, cfg *Co
 	if msg.Subtype != "" {
 		Cyan.Printf("[%s]", msg.Subtype)
 	}
-	Gray.Printf("%s", FormatLineNumCompact(lineNum, cfg.ShowLineNum))
+	Gray.Printf("%s%s", FormatElapsed(cfg), FormatLineNumCompact(lineNum, cfg.ShowLineNum))
 	if msg.Model != "" {
 		Cyan.Printf(" %s", msg.Model)
 	}
@@ -45,7 +45,7 @@ func displayAssistantMessageCompact(msg *parser.StreamMessage, lineNum int, cfg 
 		case "text":
 			if block.Text != "" {
 				BoldGreen.Print("AST")
-				Gray.Printf("%s ", FormatLineNumCompact(lineNum, cfg.ShowLineNum))
+				Gray.Printf("%s%s ", FormatElapsed(cfg), FormatLineNumCompact(lineNum, cfg.ShowLineNum))
 				// Truncate long text to single line
 				text := strings.ReplaceAll(block.Text, "\n", " ")
 				if len(text) > 100 {
@@ -62,7 +62,7 @@ func displayAssistantMessageCompact(msg *parser.StreamMessage, lineNum int, cfg 
 
 func displayToolUseCompact(tool *parser.ContentBlock, lineNum int, cfg *Config) {
 	BoldYellow.Printf("TOOL")
-	Gray.Printf("%s ", FormatLineNumCompact(lineNum, cfg.ShowLineNum))
+	Gray.Printf("%s%s ", FormatElapsed(cfg), FormatLineNumCompact(lineNum, cfg.ShowLineNum))
 	Yellow.Printf("%s", tool.Name)
 
 	// Show key inputs in compact form
@@ -111,7 +111,7 @@ func displayToolResultCompact(block *parser.ContentBlock, lineNum int, cfg *Conf
 	} else {
 		BoldMagenta.Print("RES")
 	}
-	Gray.Printf("%s ", FormatLineNumCompact(lineNum, cfg.ShowLineNum))
+	Gray.Printf("%s%s ", FormatElapsed(cfg), FormatLineNumCompact(lineNum, cfg.ShowLineNum))
 
 	contentStr := ""
 	switch v := block.Content.(type) {
@@ -143,7 +143,7 @@ func displayResultMessageCompact(msg *parser.StreamMessage, lineNum int, cfg *Co
 	} else {
 		BoldBlue.Print("OK")
 	}
-	Gray.Printf("%s", FormatLineNumCompact(lineNum, cfg.ShowLineNum))
+	Gray.Printf("%s%s", FormatElapsed(cfg), FormatLineNumCompact(lineNum, cfg.ShowLineNum))
 
 	if msg.NumTurns > 0 {
 		Blue.Printf(" turns=%d", msg.NumTurns)

--- a/display/default.go
+++ b/display/default.go
@@ -28,7 +28,7 @@ func displaySystemMessage(msg *parser.StreamMessage, lineNum int, cfg *Config) {
 	if msg.Subtype != "" {
 		Cyan.Printf(" [%s]", msg.Subtype)
 	}
-	Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+	Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 	if msg.CWD != "" {
 		Cyan.Printf("│ Working Directory: %s\n", msg.CWD)
@@ -75,7 +75,7 @@ func displayAssistantMessage(msg *parser.StreamMessage, lineNum int, cfg *Config
 	if len(textBlocks) > 0 {
 		BoldGreen.Print("┌─ ")
 		BoldGreen.Print("ASSISTANT")
-		Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 		for _, text := range textBlocks {
 			Green.Print("│ ")
@@ -97,7 +97,7 @@ func displayAssistantMessage(msg *parser.StreamMessage, lineNum int, cfg *Config
 func displayToolUse(tool *parser.ContentBlock, lineNum int, cfg *Config) {
 	BoldYellow.Print("┌─ ")
 	BoldYellow.Printf("TOOL: %s", tool.Name)
-	Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+	Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 	if cfg.Verbose {
 		Yellow.Printf("│ ID: %s\n", tool.ID)
@@ -158,7 +158,7 @@ func displayToolResult(block *parser.ContentBlock, lineNum int, cfg *Config) {
 	if block.IsError {
 		BoldRed.Print("┌─ ")
 		BoldRed.Print("TOOL RESULT ERROR")
-		Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 		if cfg.Verbose {
 			Red.Printf("│ Tool ID: %s\n", block.ToolUseID)
@@ -183,7 +183,7 @@ func displayToolResult(block *parser.ContentBlock, lineNum int, cfg *Config) {
 	} else {
 		BoldMagenta.Print("┌─ ")
 		BoldMagenta.Print("TOOL RESULT")
-		Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 		if cfg.Verbose {
 			Gray.Printf("│ Tool ID: %s\n", block.ToolUseID)
@@ -247,7 +247,7 @@ func displayResultMessage(msg *parser.StreamMessage, lineNum int, cfg *Config) {
 		BoldBlue.Print("┌─ ")
 		BoldBlue.Print("RESULT: SUCCESS")
 	}
-	Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+	Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 	// Show summary stats
 	if msg.NumTurns > 0 {

--- a/display/display.go
+++ b/display/display.go
@@ -3,6 +3,7 @@ package display
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ariel-frischer/claude-clean/parser"
 	"github.com/fatih/color"
@@ -20,9 +21,11 @@ const (
 
 // Config holds display configuration options
 type Config struct {
-	Style       OutputStyle
-	Verbose     bool
-	ShowLineNum bool
+	Style          OutputStyle
+	Verbose        bool
+	ShowLineNum    bool
+	ShowTimestamps bool
+	StartTime      time.Time
 }
 
 // Color definitions
@@ -70,6 +73,21 @@ func FormatLineNumCompact(lineNum int, showLineNum bool) string {
 		return fmt.Sprintf(" L%d", lineNum)
 	}
 	return ""
+}
+
+// FormatElapsed returns the elapsed time since cfg.StartTime if ShowTimestamps is enabled
+func FormatElapsed(cfg *Config) string {
+	if !cfg.ShowTimestamps || cfg.StartTime.IsZero() {
+		return ""
+	}
+	d := time.Since(cfg.StartTime)
+	secs := d.Seconds()
+	if secs < 60 {
+		return fmt.Sprintf(" +%.1fs", secs)
+	}
+	mins := int(secs) / 60
+	remSecs := int(secs) % 60
+	return fmt.Sprintf(" +%dm%ds", mins, remSecs)
 }
 
 // DisplayUsage shows token usage statistics

--- a/display/minimal.go
+++ b/display/minimal.go
@@ -25,7 +25,7 @@ func displaySystemMessageMinimal(msg *parser.StreamMessage, lineNum int, cfg *Co
 	if msg.Subtype != "" {
 		Cyan.Printf(" [%s]", msg.Subtype)
 	}
-	Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+	Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 	if msg.CWD != "" {
 		Cyan.Printf("  Working Directory: %s\n", msg.CWD)
@@ -65,7 +65,7 @@ func displayAssistantMessageMinimal(msg *parser.StreamMessage, lineNum int, cfg 
 	// Display text blocks
 	if len(textBlocks) > 0 {
 		BoldGreen.Printf("ASSISTANT")
-		Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 		for _, text := range textBlocks {
 			White.Printf("  %s\n", text)
@@ -92,7 +92,7 @@ func displayAssistantMessageMinimal(msg *parser.StreamMessage, lineNum int, cfg 
 
 func displayToolUseMinimal(tool *parser.ContentBlock, lineNum int, cfg *Config) {
 	BoldYellow.Printf("TOOL: %s", tool.Name)
-	Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+	Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 	if cfg.Verbose {
 		Yellow.Printf("  ID: %s\n", tool.ID)
@@ -142,7 +142,7 @@ func displayUserMessageMinimal(msg *parser.StreamMessage, lineNum int, cfg *Conf
 func displayToolResultMinimal(block *parser.ContentBlock, lineNum int, cfg *Config) {
 	if block.IsError {
 		BoldRed.Printf("TOOL RESULT ERROR")
-		Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 		if cfg.Verbose {
 			Red.Printf("  Tool ID: %s\n", block.ToolUseID)
@@ -164,7 +164,7 @@ func displayToolResultMinimal(block *parser.ContentBlock, lineNum int, cfg *Conf
 		White.Printf("  %s\n", contentStr)
 	} else {
 		BoldMagenta.Printf("TOOL RESULT")
-		Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 		if cfg.Verbose {
 			Gray.Printf("  Tool ID: %s\n", block.ToolUseID)
@@ -215,7 +215,7 @@ func displayResultMessageMinimal(msg *parser.StreamMessage, lineNum int, cfg *Co
 	} else {
 		BoldBlue.Printf("RESULT: SUCCESS")
 	}
-	Gray.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+	Gray.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 	if msg.NumTurns > 0 {
 		Blue.Printf("  Turns: %d\n", msg.NumTurns)

--- a/display/plain.go
+++ b/display/plain.go
@@ -25,7 +25,7 @@ func displaySystemMessagePlain(msg *parser.StreamMessage, lineNum int, cfg *Conf
 	if msg.Subtype != "" {
 		fmt.Printf(" [%s]", msg.Subtype)
 	}
-	fmt.Printf("%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+	fmt.Printf("%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 	if msg.CWD != "" {
 		fmt.Printf("  Working Directory: %s\n", msg.CWD)
@@ -64,7 +64,7 @@ func displayAssistantMessagePlain(msg *parser.StreamMessage, lineNum int, cfg *C
 
 	// Display text blocks
 	if len(textBlocks) > 0 {
-		fmt.Printf("ASSISTANT%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		fmt.Printf("ASSISTANT%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 		for _, text := range textBlocks {
 			fmt.Printf("  %s\n", text)
@@ -90,7 +90,7 @@ func displayAssistantMessagePlain(msg *parser.StreamMessage, lineNum int, cfg *C
 }
 
 func displayToolUsePlain(tool *parser.ContentBlock, lineNum int, cfg *Config) {
-	fmt.Printf("TOOL: %s%s\n", tool.Name, FormatLineNum(lineNum, cfg.ShowLineNum))
+	fmt.Printf("TOOL: %s%s%s\n", tool.Name, FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 	if cfg.Verbose {
 		fmt.Printf("  ID: %s\n", tool.ID)
@@ -139,7 +139,7 @@ func displayUserMessagePlain(msg *parser.StreamMessage, lineNum int, cfg *Config
 
 func displayToolResultPlain(block *parser.ContentBlock, lineNum int, cfg *Config) {
 	if block.IsError {
-		fmt.Printf("TOOL RESULT ERROR%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		fmt.Printf("TOOL RESULT ERROR%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 		if cfg.Verbose {
 			fmt.Printf("  Tool ID: %s\n", block.ToolUseID)
@@ -160,7 +160,7 @@ func displayToolResultPlain(block *parser.ContentBlock, lineNum int, cfg *Config
 
 		fmt.Printf("  %s\n", contentStr)
 	} else {
-		fmt.Printf("TOOL RESULT%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		fmt.Printf("TOOL RESULT%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 
 		if cfg.Verbose {
 			fmt.Printf("  Tool ID: %s\n", block.ToolUseID)
@@ -207,9 +207,9 @@ func displayToolResultPlain(block *parser.ContentBlock, lineNum int, cfg *Config
 
 func displayResultMessagePlain(msg *parser.StreamMessage, lineNum int, cfg *Config) {
 	if msg.IsError {
-		fmt.Printf("RESULT: ERROR%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		fmt.Printf("RESULT: ERROR%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 	} else {
-		fmt.Printf("RESULT: SUCCESS%s\n", FormatLineNum(lineNum, cfg.ShowLineNum))
+		fmt.Printf("RESULT: SUCCESS%s%s\n", FormatElapsed(cfg), FormatLineNum(lineNum, cfg.ShowLineNum))
 	}
 
 	if msg.NumTurns > 0 {


### PR DESCRIPTION
Closes #2

## Summary

- Adds a `-t` CLI flag that displays elapsed time since stream start next to each message header (e.g. `+1.5s`, `+1m30s`)
- Works across all output styles: default, compact, minimal, plain
- When `-t` is not passed, output is identical to before (no behavior change)

## Usage

```bash
claude -p 'your prompt' --output-format stream-json | cclean -t
```

Output example:
```
┌─ SYSTEM [init] +0.0s
┌─ ASSISTANT +1.2s
┌─ TOOL: Bash +2.4s
┌─ TOOL RESULT +5.8s
```

## Notes

The JSONL format doesn't embed per-message timestamps, so elapsed time is tracked from when stream processing begins. This is most useful for live piped streams (not replaying saved files, where all messages process nearly instantly).

## Test plan

- [x] All existing tests pass (`make test`)
- [x] `cclean -t mocks/claude-stream-json-simple.jsonl` shows `+0.0s` on all headers (file processes instantly)
- [x] `cclean` without `-t` produces identical output to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)